### PR TITLE
carousel: use HTTPS to load manifest

### DIFF
--- a/js/carousel-frontpage.js
+++ b/js/carousel-frontpage.js
@@ -53,7 +53,7 @@ function fillCarousel(listXml)
 
 function start_fillCarousel()
 {
-	runAjax("http://famnm.club/img/carousel/list.xml",fillCarousel);
+	runAjax("https://famnm.club/img/carousel/list.xml",fillCarousel);
 }
 
 function runAjax(url,callback)


### PR DESCRIPTION
This should fix the carousel not working over HTTPS.