### PR TITLE
 kickoff: fix quicklink button layout on mobile

### DIFF
--- a/events/kickoff.html
+++ b/events/kickoff.html
@@ -88,6 +88,10 @@ title: 2019 FRC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                 max-width: 100%;
             }
 
+            #quick-links > .btn {
+                margin: 5px auto;
+            }
+
             #map {
                 height: 400px;
             }


### PR DESCRIPTION
On mobile, all of the buttons for the quicklinks at the top of the kickoff page were all scrunched together. This adds vertical margins to each of the buttons so they're a little more separate.