### PR TITLE
Fix font on org chart

### DIFF
--- a/about/org-structure.html
+++ b/about/org-structure.html
@@ -5,6 +5,7 @@ title: Organizational Structure | FIRST® Alumni & Mentors Network at Michigan
 <html lang="en">
 <head>
     {% include title-styles.html %}
+    <link href="https://fonts.googleapis.com/css?family=Oswald" rel="stylesheet">
     <style>
         #org-pic-contain {
             padding: 10px 0;


### PR DESCRIPTION
# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description
The org chart was made with a condensed font that is not Roboto or any other font that is in common distribution. Since most devices don't have this font, the letter spacing on the chart is off:

![image](https://user-images.githubusercontent.com/4631197/54165858-e86fa900-4438-11e9-9ef7-af72383de6a3.png)

This PR adds the original font from Google Fonts so the chart has the appropriate letter spacing:

![image](https://user-images.githubusercontent.com/4631197/54165942-2ec50800-4439-11e9-890f-b172f9cd7604.png)

(I tried to adjust the SVG so it would use Roboto instead, but the `letter-spacing` CSS property didn't seem to have any effect)