### PR TITLE
Clear out FTC Kickoff Page in prep for 2019 info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 _site/
+.vscode/

--- a/events/ftc-kickoff.html
+++ b/events/ftc-kickoff.html
@@ -60,29 +60,13 @@ title: FTC Kickoff | FIRST® Alumni & Mentors Network at Michigan
         <div class="content">
             <h1 class="page-header">FAMNM <i>FIRST®</i> Tech Challenge Kickoff</h1>
                 <div id="upcoming" class="well">
-                    <p>Registration for the FAMNM FTC Kickoff is now open!</p>
-                    <a class="btn btn-primary"
-                        href="https://goo.gl/forms/NI50BeFafNKqEIlm2"
-                        onclick="openInModal(event, 'FAMNM FTC Kickoff Registration Form')">Register for kickoff</a>
-					<a class="btn btn-primary"
-						href="../img/ftc/2018-parking-map.png">
-				  	    View the parking map</a>
-					<br/>
-					<a class="btn btn-primary"
-						href="../img/ftc/2018-breakout-rooms-schedule.jpg">
-						View the schedule for the event here</a>
-					<p>This year, FTC Kickoff will be on Saturday, September 8 from 9:30am-2:00pm! Join us at the University of Michigan North Campus the <i>Rover Ruckus</i> game reveal and field, workshops (on programming, design, the team Engineering Notebook, and a robot demo from FRC teams)! Check-in will take place the DOW building (2300 Hayward Street, Ann Arbor, MI 48109). We hope to see you there!</p>
+                    <p class="font-weight-bold">This page is under construction, but details for the 2019 FTC Kickoff will be up soon!</p>
+                   
+					<p>This year, FTC Kickoff will be on Saturday, September 7 from 9:30am-2:00pm! Join us at the University of Michigan North Campus to learn more about <i>SKYSTONE</i></p>
                 </div>
                 <p class="text-par">The <i>FIRST®</i> Tech Challenge (FTC) is the middle school level in the <i>FIRST®</i> progression of programs. In 2017, FAMNM launched its FTC Kickoff event, in which we invited local teams to view the reveal of the new year's challenge
                     in early September. The event came complete with FRC Demos, inspiring speeches, and the chance to see an official FTC game field!</p>
-                <h3>Presentations</h3>
-                <ul style="margin-bottom: 1em;">
-                    <li><a href="https://docs.google.com/presentation/d/1uMnSZvsJE-Er1v_dU_rdz0eZquohUNm5tY6DDPBNq_k/edit?usp=sharing">Getting your Robot to Move</a></li>
-                    <li><a href="https://docs.google.com/presentation/d/1kzwDyM3ATFCzGbpzuhLA5x3-h7l-vHl-YgodrxN-b64/edit?usp=sharing">Programming Workshop: Control System and Source Control</a></li>
-                    <li><a href="https://docs.google.com/presentation/d/1Qqt_80k5k174Ux63pOeMJAznF333SBdbOXeD-E1ps2w">Engineering Notebooks</a></li>
-                    <li><a href="https://drive.google.com/file/d/1iJxDx5tJidQHlvXZK1A_lL3VA3oi2ox7/view?usp=sharing">MRover: Strategy in Design</a></li>
-                </ul>
-            <div id="carousel-ftc" class="carousel slide" data-ride="carousel">
+            <!-- <div id="carousel-ftc" class="carousel slide" data-ride="carousel">
                 <ol class="carousel-indicators">
                     <li data-target="#carousel-ftc" data-slide-to="0" class="active"></li>
                     <li data-target="#carousel-ftc" data-slide-to="1"></li>
@@ -128,24 +112,14 @@ title: FTC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                     </div>
                 </div>
                 <a class="carousel-control-prev" href="#carousel-ftc" role="button" data-slide="prev">
-           <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-           <span class="sr-only">Last</span>
-       </a>
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Last</span>
+                </a>
                 <a class="carousel-control-next" href="#carousel-ftc" role="button" data-slide="next">
-           <span class="carousel-control-next-icon" aria-hidden="true"></span>
-           <span class="sr-only">Next</span>
-       </a>
-            </div>
-            <!-- <h1>FAMNM <span class="italic">FIRST</span>&reg; Tech Challenge Kickoff</h1>
-    <p>The <span class="italic">FIRST</span>&reg;  Tech Challenge (FTC) season begins each year in early September with a worldwide kickoff. At this time, the year’s challenge is revealed and teams begin their design and build season. Kickoffs provide an opportunity for teams to work with each other, brainstorm ideas, learn valuable skills through workshops, and interact with a full FTC game field. </p>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/tNPvKb7-3xE" frameborder="0" allowfullscreen></iframe>
-    <h2>2017 FAMNM <span class="italic">FIRST</span>&reg; Tech Challenge Kickoff</h2>
-    <h3>University of Michigan - Ann Arbor</h3>
-    <h3>Saturday, September 9<sup>th</sup>, 2017</h3>
-   <p><h3><a href="https://goo.gl/forms/xtws44AcHhqIu3up2">Pizza Order Form</a></h3></p>
-    <img src="http://i.imgur.com/uKPJpjc.png" height=500 width=600>
-    <h3>Event Map</h3>
-    <img src="http://i.imgur.com/TuyhP2E.png" height=500 width=1000> -->
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Next</span>
+                </a>
+            </div> -->
         </div>
     </div>
     <!-- /.container -->


### PR DESCRIPTION

# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile

# Description

I've removed the old carousel and added some text about the page being under construction as planning for FTC Kickoff 2019 begins. As things like the registration form and the pizza signup are prepared, we will update the page with the new stuff.