### PR TITLE
Fix parking map link in FTC Kickoff page

### DIFF
--- a/events/ftc-kickoff.html
+++ b/events/ftc-kickoff.html
@@ -65,7 +65,7 @@ title: FTC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                         href="https://forms.gle/k1uNd5Py6aTrUnR78"
                         target="_blank">Register for kickoff</a>
 					<a class="btn btn-primary"
-						href="../img/ftc/2018-parking-map.png">
+						href="../img/ftc/2019-parking-map.png">
                         View the parking map</a>
                     <!-- <a class="btn btn-primary"
                         href="/">


### PR DESCRIPTION

# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.


# Description

Was pointing to the old location of the link instead of the new one.
