### PR TITLE
add global schedule to kickoff page (frc kickoff 2020)

### DIFF
--- a/events/kickoff.html
+++ b/events/kickoff.html
@@ -141,7 +141,8 @@ title: 2020 FRC Kickoff | FIRST® Alumni & Mentors Network at Michigan
             <!-- <p class="text-par">If your team has filled out the FIRST registration form but has not filled out the FAMNM registration form yet, please register at the link below.
                 If you wish to order a pizza lunch for your team, that link may also be found below.</p> -->
             <ul style="list-style-type: none; padding-left: 0;">
-                <!-- <li><a href="#sched">Schedule</a></li> -->
+                <li><a href="#event-map">Event Map</a></li>
+                <li><a href="#sched">Schedule</a></li>
                 <li><a href="#recharge"><span class="italic">FIRST</span>&reg; INFINITE RECHARGE&#8480;</a>
                 </li>
                 <!-- <li><a href="#um-fair">UM Fair</a></li> -->
@@ -157,25 +158,26 @@ title: 2020 FRC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                 Event Map:
             </h1>
             <iframe src="https://www.google.com/maps/d/embed?mid=1NgNVk45VFsOPxiIu1bgk4Rt2SbIVJoYI" width="640"
-                height="480"></iframe>
+                height="480" id="event-map"></iframe>
             <p class="text-par"><span class="font-weight-bold">FAMNM is excited to be hosting our fifth annual FRC
                     Kickoff!</span> Details will be posted to this page as they become available.</p>
             <p class="text-par">FRC teams from the local area come to U-M for the reveal of the 2020 FIRST Robotics
                 Competition game. The kickoff will feature a University of Michigan student organization fair,
                 pre-broadcast speakers, breakout rooms for teams to discuss the game after the reveal, and a
                 kit-of-parts distribution.</p>
-            <!-- <h2 id="sched">Schedule</h2>
-            <div class="input-group">
+            <h2 id="sched">Schedule</h2>
+            <!-- <div class="input-group">
                 <input type="text" class="form-control" placeholder="Team number"
-                    onkeypress="bNs.teamNumAccepted(event)" />
+                    onkeypress="bNs.teamNumAccepted(event, true)" />
                 <span class="input-group-append">
-                    <button class="btn btn-primary" type="button" onclick="bNs.teamNumAccepted(event)">View</button>
+                    <button class="btn btn-primary" type="button" onclick="bNs.teamNumAccepted(event, true)">View</button>
                 </span>
             </div>
             <p class="team-empty">Enter your team number above to see your team's schedule, find broadcast and breakout
                 rooms, and view additional kickoff information.</p>
             <p class="team-error"><span style="font-size: 3em; font-weight: bold;">:/</span><br /> We're sorry, we don't
-                have a schedule for that team.<br />
+                have a schedule for that team.<br /> -->
+            <p>
                 If your team is just picking up your Kit of Parts, you can pick it up at <a href="#" data-toggle="modal"
                     data-target="#mapModal" onclick="bNs.map.showKOP()">Chrysler 133</a> from 11:30 AM to 3:00 PM.</p>
             <div class="team-disp">
@@ -193,7 +195,7 @@ title: 2020 FRC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                     <tbody id="schedule">
                     </tbody>
                 </table>
-            </div> -->
+            </div>
             <img id="recharge"
                 src="https://www.firstinspires.org/sites/default/files/uploads/rightimage/infinite-recharge-web-promo_0.png"
                 style="max-height: 150px;" />
@@ -349,8 +351,6 @@ title: 2020 FRC Kickoff | FIRST® Alumni & Mentors Network at Michigan
         <ul class="sponsor-display">
             <li><a href="http://esg.engin.umich.edu/" target="_blank"><img class="center"
                         src="../../img/sponsor/esg.png" alt="College of Engineering Student Government" /></a></li>
-            <li><a href="https://ginsberg.umich.edu/" target="_blank"><img class="center"
-                        src="../../img/kickoff/sponsor/ginsberg.png" alt="Edward Ginsberg Center" /></a></li>
             <li><a href="https://engin.umich.edu" target="_blank"><img class="center" src="../../img/sponsor/coe.png"
                         alt="University of Michigan College of Engineering" /></a></li>
         </ul>

--- a/js/kickoff/page.js
+++ b/js/kickoff/page.js
@@ -106,22 +106,29 @@ var bNs = {
             else cell.parent().addClass("table-warning");
         });
     },
-    teamNumAccepted: event => {
+    teamNumAccepted: (event, isEvent) => {
         var num;
         var emptyDiv = $(".team-empty");
         var errDiv = $(".team-error");
         var dispDiv = $(".team-disp");
         var teamNumName = $("#team-num-name");
         var teamSchool = $("#team-school");
-        var target = $(event.currentTarget);
+        
+        if (isEvent) {
+            var target = $(event.currentTarget);
 
 
-        if (target.prop("type") === "text") {
-            if (event.key !== "Enter") return;
-            num = parseInt(target.val(), 10);
-        } else if (target.prop("type") === "button") {
-            num = parseInt(target.parent().prev().val(), 10);
-        } else return;
+            if (target.prop("type") === "text") {
+                if (event.key !== "Enter") return;
+                num = parseInt(target.val(), 10);
+            } else if (target.prop("type") === "button") {
+                num = parseInt(target.parent().prev().val(), 10);
+            } else return;
+
+        } else {
+            console.log("event is" + event)
+            num = event;
+        }
 
         if (bNs.activeTeam.intervalId !== undefined)
             clearInterval(bNs.activeTeam.intervalId);
@@ -131,8 +138,13 @@ var bNs = {
             bNs.loadSchedules();
             bNs.activeTeam.intervalId = setInterval(bNs.loadSchedules, 900000);
 
-            teamNumName.text(num + ": " + bNs.activeTeam.name);
-            teamSchool.text(bNs.activeTeam.school);
+            if (num !== 0) {
+                teamNumName.text(num + ": " + bNs.activeTeam.name);
+                teamSchool.text(bNs.activeTeam.school);
+            } else {
+                teamNumName.text("SCHEDULE FOR ALL TEAMS")
+                teamSchool.text(bNs.activeTeam.school);
+            }
 
             errDiv.css("display", "none");
             dispDiv.css("display", "block");
@@ -148,6 +160,8 @@ var bNs = {
         for (var i = 0; i < bNs.teams.length; ++i) {
             if (bNs.teams[i].number === num) {
                 bNs.activeTeam = bNs.teams[i];
+                console.log("set active team");
+                console.log(bNs.activeTeam);
                 return bNs.teams[i].number;
             }
         }
@@ -404,14 +418,16 @@ $(document).ready(function () {
     }).done(teams => {
         bNs.teams = teams;
 
-        //Load the current team
-        var team = localStorage.getItem("team");
+        // //Load the current team
+        // var team = localStorage.getItem("team");
 
-        if (team.length > 0) {
-            var teamInput = $($(".input-group").children().get(0));
-            teamInput.val(team);
-            teamInput.next().trigger("click");
-        }
+        // if (team.length > 0) {
+        //     var teamInput = $($(".input-group").children().get(0));
+        //     teamInput.val(team);
+        //     teamInput.next().trigger("click");
+        // }
+
+        bNs.teamNumAccepted(0, false)
     });
 
     //Initialize countdown clock

--- a/js/kickoff/teamlist.json
+++ b/js/kickoff/teamlist.json
@@ -1,5 +1,12 @@
 [
 	{
+		"number": 0,
+		"name": "ALL",
+		"school": "University of Michigan North Campus",
+		"broadcast": "TBA - Per Team",
+		"breakout": "TBA - Per Team"
+	},
+	{
 		"number": 66,
 		"name": "Grizzly Robotics",
 		"school": "Ypsilanti STEMM Middle College",


### PR DESCRIPTION
# Checklist

  * [x] This update has been tested thoroughly enough to ensure there are no
        functional bugs or obvious layout issues.
  * [x] This update has been tested in both desktop and mobile layouts.
  * [x] This update does not break any existing functionality, layout, or style
        rules, unless the update is explicitly intended to remove or update such
        functionality, layout, or style rules.
  * [x] This update is free of any code intended only for debugging or testing
        purposes.
  * [x] This update follows the FAMNM Website Code Style Guide.
  * [x] This update meets the visual style requirements as specified in the
        FAMNM Website Visual Style Guide, and any additional visual elements not
        previously specified in the FAMNM Website Visual Style Guide have been
        styled so as not to clash visually with the rest of the site.

# Description

As a sort-of elegant 'hack' on top of Paul's kickoff code, I added to the JSON of team list an entry for a fake `Team 0` which says "TBA" for the team-specific information. Then, in the `page.js` script for the kickoff page, when the page is loaded, I call the function to load a team's schedule, loading the team with number `0`. 

I had to do some slight modifications to the javascript as Paul's function took in a JS event and parsed out the team number, and I wanted to provide a team number directly.

This results in anybody who loads the page seeing this schedule, which states that team-specific information will be announced shortly.