### PR TITLE
hotfix: empty item in Events dropdown

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,7 +32,7 @@
             <ul class="dropdown-menu bg-famnm-blue">
                 <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/frc-offseason.html" %} active{% endif %}"><a class="nav-link" href="{{site.url}}/events/frc-offseason.html">FRC Offseason</a></li>
                 <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/kickoff.html" %} active{% endif %}"><a class="nav-link" href="{{site.url}}/events/kickoff.html">FRC Kickoff</a></li>
-                <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/rqb.html" %} active{% endif %}"><a class="nav-link" href="{{site.url}}/events/rqb.html">Robot Quick Build</a><li class="dropdown-item">
+                <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/rqb.html" %} active{% endif %}"><a class="nav-link" href="{{site.url}}/events/rqb.html">Robot Quick Build</a></li>
                 <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/ftc-kickoff.html" %} active{% endif %}" ><a class="nav-link" href="{{site.url}}/events/ftc-kickoff.html">FTC Kickoff</a></li>
                 <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/robotics-day.html" %} active{% endif %}" ><a class="nav-link" href="{{site.url}}/events/robotics-day.html">FAMNM Robotics Day</a></li>
                 <li class="bg-famnm-blue dropdown-item{% if page.url == "/events/ri3d/index.html" %} active{% endif %}" ><a class="nav-link" href="{{site.url}}/events/ri3d/index.html">Robot in 3 Days</a></li>


### PR DESCRIPTION
# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description

<!-- Provide a brief yet thorough description of your changes here. -->
An empty list item was present in the Events dropdown menu on the header between Robot Quick Build and FTC Kickoff. This hotfix removes this item.
