### PR TITLE
Remove cancellation message on FTC Kickoff page

### DIFF
--- a/events/ftc-kickoff.html
+++ b/events/ftc-kickoff.html
@@ -23,10 +23,6 @@ title: FTC Kickoff | FIRST® Alumni & Mentors Network at Michigan
                     target="_blank" rel="noopener noreferrer">View Workshop Presentation Slides</a>
                 </p>
                 <br /> -->
-                <p class="text-par font-weight-bold">
-                    Unfortunately, FAMNM was unable to host an FTC Kickoff event
-                    this fall. We hope to see you back on campus for FTC Kickoff 2021!
-                </p>
             </div>
             <div id="carousel-ftc" class="carousel slide" data-ride="carousel">
                 <ol class="carousel-indicators"></ol>


### PR DESCRIPTION
<!-- Use this template for submitting hotfix pull requests. Make sure that your
     pull request meets each item in the checklist below (where applicable),
     and that you check each item before submitting the pull request.
     
     Be sure to apply the `hotfix' label to your pull request. -->

# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description

This removes the banner that says "Unfortunately, FAMNM was unable to host an FTC Kickoff event this fall. We hope to see you back on campus for FTC Kickoff 2021!" from the FTC Kickoff page.
