### PR TITLE
Add a (disabled) button to the FRC kickoff registration form

### DIFF
--- a/events/kickoff.html
+++ b/events/kickoff.html
@@ -130,9 +130,16 @@ orgs:
             <div>
                 <h1>FAMNM FRC Kickoff</h1>
             </div>
-            <p class="text-par font-weight-bold">
-                We hope teams are safe and healthy. FAMNM hopes to return to an in-person kickoff in 2022!
-            </p>
+            <div class="text-par font-weight-bold text-center">
+                FAMNM plans to hold an in-person kickoff in January 2022!
+            </div>
+            <div class="pt-3">
+                <a class="btn famnm-btn-secondary disabled"
+                href="https://docs.google.com/forms/d/e/1FAIpQLSeB5MKEnCdOmkUNhrBhjbKeUlXOFNP0RAXS3jYOcdRlmxQLww/viewform?usp=sf_link"
+                target="_blank" rel="noopener noreferrer">Register Your FRC Team</a>
+                <br />
+                The registration form will be opened soon
+            </div>
             <!-- <p class="text-par">
                 If your team has filled out the FIRST registration form but has not filled out the FAMNM registration form yet, please register at the link below.
                 If you wish to order a pizza lunch for your team, that link may also be found below.
@@ -222,7 +229,7 @@ orgs:
                 </div>
                 {% endfor %}
             </div> -->
-            <h3 class="text-center">Sponsors</h3>
+            <h3 class="text-center pt-5">Sponsors</h3>
             <ul class="sponsor-display">
                 <li><a href="http://esg.engin.umich.edu/" target="_blank" rel="noopener noreferrer"><img class="center" src="../../img/sponsor/esg.png" alt="College of Engineering Student Government" /></a></li>
                 <li><a href="https://engin.umich.edu" target="_blank" rel="noopener noreferrer"><img class="center" src="../../img/sponsor/coe.png" alt="University of Michigan College of Engineering" /></a></li>


### PR DESCRIPTION
<!-- Use this template for submitting most pull requests. Make sure that your
     pull request meets each item in the checklist below (where applicable),
     and that you check each item before submitting the pull request. -->

# Checklist

  * [x] This update has been tested thoroughly enough to ensure there are no
        functional bugs or obvious layout issues.
  * [x] This update has been tested in both desktop and mobile layouts.
  * [x] This update does not break any existing functionality, layout, or style
        rules, unless the update is explicitly intended to remove or update such
        functionality, layout, or style rules.
  * [x] This update is free of any code intended only for debugging or testing
        purposes.
  * [x] This update follows the FAMNM Website Code Style Guide.
  * [x] This update meets the visual style requirements as specified in the
        FAMNM Website Visual Style Guide, and any additional visual elements not
        previously specified in the FAMNM Website Visual Style Guide have been
        styled so as not to clash visually with the rest of the site.

# Description

<!-- Provide a brief yet thorough description of your changes here. -->
Teams can't register yet, but now it's obvious that at least a form *will* be available soon.
