### PR TITLE
Remove gap between menu bar and content

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4,7 +4,7 @@ html {
 
 body {
     min-height: 100%;
-    padding-top: 70px;
+    padding-top: 56px;
     font-family: 'Roboto', sans-serif;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description

Adjusted the top padding of `<body>` to remove the gap between the menu bar and the content (such as the homepage carousel).