### PR TITLE
Complete kickoff, update meeting info

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,11 @@ featured_announcements:
    image: img/kickoff/kickoff-2017-stamps.png
    alt: FRC Kickoff in Stamps Auditorium
    text:
-     FAMNM will host a kickoff event for the 2023 season of <i>FIRST</i> Robotics Competition,
-     <i>CHARGED UP</i>, on <time datetime="2023-01-07">January 7th, 2023</time> at the University of Michigan's North Campus in Ann Arbor.
+     FAMNM hosted a successful kickoff event for the 2023 season of <i>FIRST</i> Robotics Competition,
+     <i>CHARGED UP</i>, on <time datetime="2023-01-07">January 7th, 2023</time> at the University of Michigan's North Campus in Ann Arbor. Good luck, teams!
    links:
-    - text: Register your team
+    - text: View schedule and rooms
       link: /events/kickoff
-    - text: Sign-up to Volunteer
-      link: https://docs.google.com/spreadsheets/d/1ABdTMUGKLH1FMLiaiVpFzJC73pmI4UyIkRlFQL7S7lw/edit?usp=sharing
  - title: Edison bots available
    image: img/index/edison.jpg
    alt: A small, two-wheeled robot with three buttons and LEGO-compatible sockets on a mat with several barcodes
@@ -28,12 +26,12 @@ featured_announcements:
    image: img/index/game-night-2018.jpg
    alt: FAMNM game night
    text:
-     Email FAMNM's Director of Internal Affairs at <a href="mailto:famnm.admin@umich.edu">famnm.admin@umich.edu</a>,
-     and they will set you up with everything you need to become a member. Also, come to our General Body and Planning Meetings on
-     <strong>Mondays at 8:30 PM</strong> in <strong>2147 GGBL</strong>.
+     Fill out our <a href="https://docs.google.com/forms/d/1H2tbLWFuDOSvxJC3u9dfkfBNkp8iYOowHkWAzAI-Tfg/viewform">Winter 2023 interest form</a> so that
+     we can add you to our Slack workspace and mailing list. Also, come to our General Body and Planning Meetings on
+     <strong>Mondays at 7:30 PM</strong> in <strong>1690 BBB</strong>.
    links:
-    - text: Join FAMNM
-      link: mailto:famnm.admin@umich.edu
+    - text: Interest form
+      link: https://docs.google.com/forms/d/1H2tbLWFuDOSvxJC3u9dfkfBNkp8iYOowHkWAzAI-Tfg/viewform
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -104,19 +102,6 @@ featured_announcements:
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="sr-only">Next</span>
         </button>
-    </div>
-
-    <div class="container p-5">
-        <h2 class="text-center">FRC Kickoff Volunteering</h2>
-        <div class="row align-items-center p-3">
-            <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpgEJkdnZ1KXa-IJtcfLmCmq0SkN_8-EI0J8aqz3uQKwBuov_PRBS065Jwb3brLsl1HiDS4pzbwCxq/pubhtml?widget=true&amp;headers=false" height="500"></iframe>
-        </div>
-        <div class="text-center p-3">
-            <a href="https://docs.google.com/spreadsheets/d/1ABdTMUGKLH1FMLiaiVpFzJC73pmI4UyIkRlFQL7S7lw/edit?usp=sharing" target="_blank" rel="noreferrer noopener">
-                <button type="button" class="btn btn-primary">Sign-up to Volunteer for Kickoff</button>
-            </a>
-            <p class="p-2">Please put yourself under "Potential Volunteers" if you're unsure if/when you can make it</p>
-        </div>
     </div>
     {% include footer.html %}
     {% include scripts.html %}


### PR DESCRIPTION
# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description

- Update the kickoff announcement from future tense to past tense
- Update the meeting time and location for GBMs and planning meetings in W23
- Publish a link to the W23 interest form
- Remove the 2023 FRC kickoff volunteer spreadsheet

