### PR TITLE
Remove NC27 from kickoff parking options

### DIFF
--- a/src/pages/events/kickoff.astro
+++ b/src/pages/events/kickoff.astro
@@ -80,8 +80,7 @@ const carouselItems = [
                         a guest speaker, U-M campus tours, kit distribution, and breakout rooms for registered teams.
                         Upon arrival, teams may park in blue spaces in
                         <Link to="https://maps.app.goo.gl/kAKi4yPQLRHosNh77">NC20</Link>,
-                        <Link to="https://maps.app.goo.gl/7NmSLk1wEvJ4dRPc7">NC21</Link>,
-                        <Link to="https://maps.app.goo.gl/xz3gVdaAnixMomXJA">NC27</Link>, and
+                        <Link to="https://maps.app.goo.gl/7NmSLk1wEvJ4dRPc7">NC21</Link>, and
                         <Link to="https://maps.app.goo.gl/pnqWgyf8x8iq7K8m9">NC26</Link>.
                     </p>
                 </div>
@@ -95,8 +94,8 @@ const carouselItems = [
                     <a class="btn famnm-btn-secondary btn-lg gap-3"
                             rel="noreferrer noopener"
                             target="_blank"
-                            href="https://maps.app.goo.gl/xz3gVdaAnixMomXJA"
-                            data-bs-toggle="tooltip" data-placement="bottom" title="Directions to NC27, which is closest to kickoff activities among all parking options">
+                            href="https://maps.app.goo.gl/7NmSLk1wEvJ4dRPc7"
+                            data-bs-toggle="tooltip" data-placement="bottom" title="Directions to NC21, which is closest to kickoff activities among all parking options">
                         <i class="fa-solid fa-diamond-turn-right"></i>
                         Directions to Campus
                     </a>


### PR DESCRIPTION
# Checklist

**This pull request is a hotfix**

  * [x] This patch is under 50 lines total.
  * [x] This patch contains only small content additions or critical
        functionality, layout, or style fixes.
  * [x] This patch follows the FAMNM Website Code Style Guide.
  * [x] This patch makes no changes to existing functionality, layout, or style
        rules, beyond the issue it is intended to fix.
  * [x] If the patch fixes a functionality, layout, or style issue, the patch
        has been tested on both desktop and mobile platforms.

# Description

Remove NC27 from the list of parking options for FRC kickoff 2024
